### PR TITLE
メッセージ送信機能を実装(2)

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -19,6 +19,10 @@ class MessagesController < ApplicationController
 
   private
 
+  def message_params
+    params.require(:message).permit(:content, :image).merge(user_id: current_user.id)
+  end
+
   def set_group
     @group = Group.find(params[:group_id])
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,6 +7,14 @@ class MessagesController < ApplicationController
   end
 
   def create
+    @message = @group.messages.new(message_params)
+    if @message.save
+      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+    else
+      @messages = @group.messages.includes(:user)
+      flash.now[:alert] = 'メッセージを入力してください。'
+      render :index
+    end
   end
 
   private

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -2,6 +2,8 @@ class MessagesController < ApplicationController
   before_action :set_group
 
   def index
+    @message = Message.new
+    @messages = @group.messages.includes(:user)
   end
 
   def create

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -1,8 +1,15 @@
 class MessagesController < ApplicationController
+  before_action :set_group
 
   def index
   end
 
   def create
+  end
+
+  private
+
+  def set_group
+    @group = Group.find(params[:group_id])
   end
 end

--- a/app/views/shared/_chat-main.html.haml
+++ b/app/views/shared/_chat-main.html.haml
@@ -20,10 +20,10 @@
       %p.message__text
         hello!
   .form
-    %form#new_message.new_message{"accept-charset": "UTF-8", action: "#", enctype: "multipart/form-data", method: "post"}
+    = form_for [@group, @message], class: "new_message", id: "new_message", enctype: "multipart/form_data" do |f|
       .input-box
-        %input#message_content.input-box__text{name: "message[content]", placeholder: "type a message", type: "text"}
-        %label.input-box__image{for: "message_image"}
+        = f.text_field :content, class: "input-box__text", id: "message_content", placeholder: "type a message"
+        = f.label :image, class: "input-box__image", for: "message_image" do
           = fa_icon "image"
-          %input#message_image.input-box__image__file{name: "message[image]", type: "file"}
-      %input.submit-btn{name: "commit", type: "submit", value: "Send"}
+          = f.file_field :image, class: "input-box__image__file hidden", id: "message_image"
+      = f.submit "Send", class: "submit-btn"


### PR DESCRIPTION
# WHAT
メッセージ送信機能を実装した。
messagesコントローラにindexアクション、createアクションを定義した。
chat-mainのフォーム部分をform-forヘルパーを使って記述、リクエストを送れるように設定した。

# WHY
グループで作成したメッセージをmvcの流れで処理するため。
