### PR TITLE
ビューの調整

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -6,7 +6,7 @@ class Group < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   def show_last_message
-    if (last_message = message.last).present?
+    if (last_message = messages.last).present?
       if last_message.content?
         last_message.content
       else

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -7,9 +7,13 @@ class Group < ApplicationRecord
 
   def show_last_message
     if (last_message = message.last).present?
-    
+      if last_message.content?
+        last_message.content
+      else
+        '画像が投稿されています'
+      end
     else
       'まだメッセージはありません。'
     end
-
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -2,5 +2,9 @@ class Group < ApplicationRecord
   has_many :messages
   has_many :group_users
   has_many :users, through: :group_users
+
   validates :name, presence: true, uniqueness: true
+
+  def show_last_message
+  end
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -6,5 +6,10 @@ class Group < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
   def show_last_message
-  end
+    if (last_message = message.last).present?
+    
+    else
+      'まだメッセージはありません。'
+    end
+
 end

--- a/app/views/shared/_chat-main.html.haml
+++ b/app/views/shared/_chat-main.html.haml
@@ -2,7 +2,7 @@
   .main-header
     .main-header__left-box
       %h2.main-header__left-box__current-group
-        test-group
+        = @group.name
       %ul.main-header__left-box__member-list
         Member：
         %li.main-header__left-box__member-list__member

--- a/app/views/shared/_chat-main.html.haml
+++ b/app/views/shared/_chat-main.html.haml
@@ -5,8 +5,9 @@
         = @group.name
       %ul.main-header__left-box__member-list
         Member：
-        %li.main-header__left-box__member-list__member
-          sample
+        - @group.users.each do |member|
+          %li.main-header__left-box__member-list__member
+            = member.name
     = link_to edit_group_path(@group) do
       .main-header__edit-btn
         Edit

--- a/app/views/shared/_chat-main.html.haml
+++ b/app/views/shared/_chat-main.html.haml
@@ -11,14 +11,7 @@
       .main-header__edit-btn
         Edit
   .messages
-    .message
-      .message__upper-info
-        %p.message__upper-info__talker
-          sample
-        %p.message__upper-info__date
-          sample-date
-      %p.message__text
-        hello!
+    = render partial: 'shared/message', collection: @messages
   .form
     = form_for [@group, @message], class: "new_message", id: "new_message", enctype: "multipart/form_data" do |f|
       .input-box

--- a/app/views/shared/_chat-side.html.haml
+++ b/app/views/shared/_chat-side.html.haml
@@ -17,4 +17,4 @@
           %p.group__group-name
             = group.name
           %p.group__latest-message
-            hello!
+            = group.show_last_message

--- a/app/views/shared/_message.html.haml
+++ b/app/views/shared/_message.html.haml
@@ -1,0 +1,10 @@
+.message
+  .message__upper-info
+    %p.message__upper-info__talker
+      = message.user.name
+    %p.message__upper-info__date
+      = message.created_at.strftime("%Y/%m/%d %H:%M")
+  %p.message__text
+    - if message.content.present?
+      = message.content
+    = image_tag message.image.url, class: "message__image" if message.image.present?

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module ChatSpace
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
     config.generators do |g|
       g.stylesheets false
       g.javascripts false


### PR DESCRIPTION
# WHAT
グループに投稿されたメッセージを表示。
サイドバーのグループ部分に最新のメッセージを表示。
ヘッダーのグループ名に当該グループ名を表示。
グループに所属している ユーザーの名前を表示。
メッセージの日時の表示を日本時間に修正。

# WHY
実装した機能によってグループ名やメッセージなどを動的に表示できるようにするため。
